### PR TITLE
Changes Uchiwa version to 0.25.0-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN \
     curl https://sensu.global.ssl.fastly.net/apt/pubkey.gpg | apt-key add - && \
     echo "deb https://sensu.global.ssl.fastly.net/apt xenial main" > /etc/apt/sources.list.d/sensu.list
 
-ENV UCHIWA_VERSION=0.23.1-1
+ENV UCHIWA_VERSION=0.25.0-1
 RUN \
     apt-get update && \
     apt-get install -y uchiwa=${UCHIWA_VERSION} && \


### PR DESCRIPTION
Just dropping a PR for the latest version of Uchiwa. It has the ability to add/edit proxy clients via. the UI which is pretty great!

Tested locally and it built and ran okay.